### PR TITLE
[FEAT] CORS 설정

### DIFF
--- a/src/main/java/SDD/smash/Config/SecurityConfig.java
+++ b/src/main/java/SDD/smash/Config/SecurityConfig.java
@@ -58,12 +58,10 @@ public class SecurityConfig {
 
                                 List<String> allowed = Arrays.asList(frontUrl);
                                 config.setAllowedOrigins(allowed);
-                                config.setAllowedMethods(singletonList("*")); // 허용할 메소드 Get ect on
-                                config.setAllowCredentials(true);
-                                config.setAllowedHeaders(singletonList("*"));
+                                config.setAllowedMethods(List.of("GET", "OPTIONS")); // GET, OPTIONS(프리플라이트)만 허용
+                                config.setAllowCredentials(false); // 비회원 + 쿠기 사용 안함
+                                config.setAllowedHeaders(List.of("Content-Type", "Accept"));
                                 config.setMaxAge(3600L);
-
-                                config.setExposedHeaders(singletonList("Authorization"));
 
                                 return config;
                             }


### PR DESCRIPTION
## 📝 작업 내용
- 허용할 요청 메서드 제한(GET, OPTIONS)
- allowCredentials(false); 쿠키 등 사용 안하기때문
- 최소한의 헤더만 허용(Content-Type, Accept)