### PR TITLE
[FEAT] RateLimit

### DIFF
--- a/src/main/java/SDD/smash/Config/SecurityConfig.java
+++ b/src/main/java/SDD/smash/Config/SecurityConfig.java
@@ -1,6 +1,9 @@
 package SDD.smash.Config;
 
+import SDD.smash.Security.Filter.ApiRateLimitFilter;
+import SDD.smash.Security.Service.ApiRateLimitService;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,6 +12,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -19,7 +23,10 @@ import static java.util.Collections.singletonList;
 
 @EnableWebSecurity
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final ApiRateLimitService apiRateLimitService;
 
     @Value("${front_url}")
     private String[] frontUrl;
@@ -68,6 +75,10 @@ public class SecurityConfig {
                         }));
         http
                 .formLogin((formLogin) -> formLogin.disable());
+
+
+        http
+                .addFilterBefore(new ApiRateLimitFilter(apiRateLimitService), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/SDD/smash/Security/Filter/ApiRateLimitFilter.java
+++ b/src/main/java/SDD/smash/Security/Filter/ApiRateLimitFilter.java
@@ -1,0 +1,41 @@
+package SDD.smash.Security.Filter;
+
+import SDD.smash.Security.Service.ApiRateLimitService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class ApiRateLimitFilter extends OncePerRequestFilter {
+
+    private final ApiRateLimitService apiRateLimitService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException
+    {
+        // 프리플라이트의 경우 통과
+        if("OPTIONS".equalsIgnoreCase(request.getMethod()))
+        {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String ip = request.getRemoteAddr();
+
+        // 락 여부 확인
+        long ipTtl = apiRateLimitService.checkIpLockAndINCAndMaybeLock(ip);
+        if(ipTtl > 0)
+        {
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            response.setHeader("Retry-After", String.valueOf(ipTtl)); // 초 단위
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/SDD/smash/Security/Service/ApiRateLimitService.java
+++ b/src/main/java/SDD/smash/Security/Service/ApiRateLimitService.java
@@ -1,0 +1,74 @@
+package SDD.smash.Security.Service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ApiRateLimitService {
+
+    private static final String ZSET_PREFIX = "ip_rate";
+    private static final String LOCK_PREFIX = "ip_lock";
+
+    private static final long WINDOW_SECONDS = 10;     // 윈도우 크기(초)
+    private static final long ALLOWED_COUNT  = 30;    // 허용할 횟수
+    private static final long LOCK_TTL_MS    = 60_000; // 락 TTL(ms)
+
+    private static final String LUA = ""
+            + "local zsetKey   = KEYS[1]\n"
+            + "local lockKey   = KEYS[2]\n"
+            + "local now       = tonumber(ARGV[1])\n"
+            + "local windowSec = tonumber(ARGV[2])\n"
+            + "local limit     = tonumber(ARGV[3])\n"
+            + "local lockTtl   = tonumber(ARGV[4])\n"
+            + "local existingTtl = redis.call('PTTL', lockKey)\n"
+            + "if existingTtl and existingTtl > 0 then\n"
+            + "  return existingTtl\n"
+            + "end\n"
+            + "local windowStart = now - (windowSec * 1000)\n"
+            + "redis.call('ZREMRANGEBYSCORE', zsetKey, '-inf', windowStart - 1)\n"
+            + "local seqKey = zsetKey .. ':seq'\n"
+            + "local seq = redis.call('INCR', seqKey)\n"
+            + "local member = tostring(now) .. '-' .. tostring(seq)\n"
+            + "redis.call('ZADD', zsetKey, now, member)\n"
+            + "local desiredTtl = (windowSec * 1000) + lockTtl + 5000\n"
+            + "local zttl = redis.call('PTTL', zsetKey)\n"
+            + "if (not zttl) or (zttl < 0) or (zttl < desiredTtl) then\n"
+            + "  redis.call('PEXPIRE', zsetKey, desiredTtl)\n"
+            + "  redis.call('PEXPIRE', seqKey, desiredTtl)\n"
+            + "end\n"
+            + "local cnt = redis.call('ZCOUNT', zsetKey, windowStart, now)\n"
+            + "if cnt > limit then\n"
+            + "redis.call('SET', lockKey, '1', 'PX', lockTtl)\n"
+            + "return lockTtl\n"
+            + "end\n"
+            + "return 0\n";
+    private static final RedisScript<Long> SCRIPT = RedisScript.of(LUA, Long.class);
+
+    private final RedisTemplate<String, String> redis;
+
+    public long checkIpLockAndINCAndMaybeLock(String ip)
+    {
+        String zsetKey = ZSET_PREFIX + ":" + ip;
+        String lockKey = LOCK_PREFIX + ":" + ip;
+
+        long now = System.currentTimeMillis();
+
+        List<String> keys = Arrays.asList(zsetKey, lockKey);
+        Object[] args = new Object[]{
+                String.valueOf(now),
+                String.valueOf(WINDOW_SECONDS),
+                String.valueOf(ALLOWED_COUNT),
+                String.valueOf(LOCK_TTL_MS)
+        };
+
+        Long res = redis.execute(SCRIPT, keys, args);
+        return res == null ? 0L : (res + 999)/1000;
+    }
+
+}


### PR DESCRIPTION
## 🔍 관련 이슈
- Closes #32 

## 📝 작업 내용
- IP당 10초 내 30번 요청 가능
- 초과 시 60초간 429 반환 및 Retry-After 헤더로 남은 시간(초) 반환
- Lua 스크립트를 활용해 동시에 동일 IP의 요청이 도착하더라도 순차적으로 락 확인 및 설정을 해 경쟁조건 방지

## ✔️ 테스트 
- 간단한 k6 테스트 완료

