### PR TITLE
[Fix] 파라미터 오타 수정 & -> ?

### DIFF
--- a/src/main/java/SDD/smash/Job/Service/JobService.java
+++ b/src/main/java/SDD/smash/Job/Service/JobService.java
@@ -65,7 +65,7 @@ public class JobService {
     private String generateUrl(String sigunguCode)
     {
         return BASE_URL + PATH
-                + "&region=" + sigunguCode
+                + "?region=" + sigunguCode
                 + "&resultCnt=10"
                 + "&pageIndex=1";
     }


### PR DESCRIPTION
## 📝 작업 내용
- 고용24 채용정보로 연결되는 URL의 파라미터 수정
<img width="585" height="360" alt="image" src="https://github.com/user-attachments/assets/c15308d2-1908-44fe-aeec-9e690df890fc" />

&를 ?로 변경